### PR TITLE
1. Check also the parent package's update site, and 2. use safe method to check if not core extension

### DIFF
--- a/administrator/components/com_installer/models/manage.php
+++ b/administrator/components/com_installer/models/manage.php
@@ -293,11 +293,13 @@ class InstallerModelManage extends InstallerModel
 	{
 		$query = $this->getDbo()->getQuery(true)
 			->select('e.*')
-			->select('u.update_site_id')
-			->select('2*protected+(1-protected)*enabled AS status')
+			->select('u1.update_site_id')
+			->select('u2.update_site_id AS update_site_id_pkg')
+			->select('2*e.protected+(1-e.protected)*e.enabled AS status')
 			->from('#__extensions AS e')
-			->leftJoin('#__update_sites_extensions AS u ON u.extension_id = e.extension_id')
-			->where('state = 0');
+			->leftJoin('#__update_sites_extensions AS u1 ON u1.extension_id = e.extension_id')
+			->leftJoin('#__update_sites_extensions AS u2 ON u2.extension_id = e.extension_id')
+ 			->where('e.state = 0');
 
 		// Process select filters.
 		$status   = $this->getState('filter.status');

--- a/administrator/components/com_installer/models/manage.php
+++ b/administrator/components/com_installer/models/manage.php
@@ -298,7 +298,7 @@ class InstallerModelManage extends InstallerModel
 			->select('2*e.protected+(1-e.protected)*e.enabled AS status')
 			->from('#__extensions AS e')
 			->leftJoin('#__update_sites_extensions AS u1 ON u1.extension_id = e.extension_id')
-			->leftJoin('#__update_sites_extensions AS u2 ON u2.extension_id = e.extension_id')
+			->leftJoin('#__update_sites_extensions AS u2 ON u2.extension_id = e.package_id')
  			->where('e.state = 0');
 
 		// Process select filters.

--- a/administrator/components/com_installer/views/manage/tmpl/default.php
+++ b/administrator/components/com_installer/views/manage/tmpl/default.php
@@ -103,7 +103,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 									<?php echo $item->name; ?>
 								</span>
 							</label>
-							<?php if ($item->extension_id > 999 && $item->update_site_id === null) : ?>
+							<?php if ($item->extension_id > 999 && $item->update_site_id === null && $item->update_site_id_pkg === null) : ?>
 								<span class="badge badge-important bold hasTooltip"
 									title="<?php echo JText::_('COM_INSTALLER_UPDATE_NOT_SUPPORTED_DESC'); ?>">
 									<?php echo JText::_('COM_INSTALLER_UPDATE_NOT_SUPPORTED'); ?>

--- a/administrator/components/com_installer/views/manage/tmpl/default.php
+++ b/administrator/components/com_installer/views/manage/tmpl/default.php
@@ -103,7 +103,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 									<?php echo $item->name; ?>
 								</span>
 							</label>
-							<?php if ($item->extension_id > 999 && $item->update_site_id === null && $item->update_site_id_pkg === null) : ?>
+							<?php if ($item->extension_id > 9999 && $item->update_site_id === null && $item->update_site_id_pkg === null) : ?>
 								<span class="badge badge-important bold hasTooltip"
 									title="<?php echo JText::_('COM_INSTALLER_UPDATE_NOT_SUPPORTED_DESC'); ?>">
 									<?php echo JText::_('COM_INSTALLER_UPDATE_NOT_SUPPORTED'); ?>

--- a/administrator/components/com_installer/views/manage/tmpl/default.php
+++ b/administrator/components/com_installer/views/manage/tmpl/default.php
@@ -103,7 +103,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 									<?php echo $item->name; ?>
 								</span>
 							</label>
-							<?php if (JExtensionHelper::checkIfCoreExtension($item->type, $item->element, $item->client_id, $item->folder) === false && $item->update_site_id === null && $item->update_site_id_pkg === null) : ?>
+							<?php if ($item->update_site_id === null && $item->update_site_id_pkg === null && JExtensionHelper::checkIfCoreExtension($item->type, $item->element, $item->client_id, $item->folder) === false) : ?>
 								<span class="badge badge-important bold hasTooltip"
 									title="<?php echo JText::_('COM_INSTALLER_UPDATE_NOT_SUPPORTED_DESC'); ?>">
 									<?php echo JText::_('COM_INSTALLER_UPDATE_NOT_SUPPORTED'); ?>

--- a/administrator/components/com_installer/views/manage/tmpl/default.php
+++ b/administrator/components/com_installer/views/manage/tmpl/default.php
@@ -103,7 +103,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 									<?php echo $item->name; ?>
 								</span>
 							</label>
-							<?php if ($item->extension_id > 9999 && $item->update_site_id === null && $item->update_site_id_pkg === null) : ?>
+							<?php if (JExtensionHelper::checkIfCoreExtension($item->type, $item->element, $item->client_id, $item->folder) === false && $item->update_site_id === null && $item->update_site_id_pkg === null) : ?>
 								<span class="badge badge-important bold hasTooltip"
 									title="<?php echo JText::_('COM_INSTALLER_UPDATE_NOT_SUPPORTED_DESC'); ?>">
 									<?php echo JText::_('COM_INSTALLER_UPDATE_NOT_SUPPORTED'); ?>


### PR DESCRIPTION
1. In case if an extension belongs to package, check also the package's update site, i.e. display the warning only if there is neither an update site for the package itself nor for its package ID.
2. Use the new JExtensionHelper class to check if not core extension instead of the unsafe check for extension_id > 999.

You might have to fix code style of my PR after having merged it: The line with the condition in the view for check if the warning has to be displayed is a bit long after my changes, so you may have to do some line break.